### PR TITLE
Update GCC command

### DIFF
--- a/micro.ml
+++ b/micro.ml
@@ -317,7 +317,7 @@ let compile file =
         close_stream stm; 
         close_generator g;
         let _ = Sys.command ("nasm -f elf " ^ g.file) in
-        let _ = Sys.command ("gcc -o " ^ out ^ " " ^ out ^ ".o") in ()
+        let _ = Sys.command ("gcc -m32 -o " ^ out ^ " " ^ out ^ ".o") in ()
     with Syntax_error e ->
             Format.printf "syntax error: %s\n" e;
             Format.print_flush()


### PR DESCRIPTION
on 64-bit Systems, GCC will default to 64-bit linking whereas the Assembly is written and compiled for x86. With this change (adding `-m32` flag), the linking will be done in the x86 mode either, solving linker issues in 64-bit Systems.